### PR TITLE
Update core-js peerDependencies version to the maintained one

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-bundle": "vue-cli-service build --target lib --name vue3-xml-viewer ./src/components/main.js"
   },
   "peerDependencies": {
-    "core-js": "^3.22.2",
+    "core-js": "^3.23.3",
     "vue": "^3.2.33"
   },
   "devDependencies": {


### PR DESCRIPTION
Update core-js peerDependencies version to 3.23.3 because the previous versions are deprecated:
> core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.